### PR TITLE
Fix third-level items doubling

### DIFF
--- a/src/web/js/scripts.js
+++ b/src/web/js/scripts.js
@@ -69,7 +69,7 @@ dvizh.tree = {
             function (response) {
                 if (response && response != 'delete') {
                     if ($(self).parents('li:first').hasClass('main')) {
-                        $(self).parents('.main').append(response);
+                        $(self).closest('.main').append(response);
                     } else {
                         $(self).parents('.children-li').append(response);
                     }


### PR DESCRIPTION
Third-level items are inserted twice: to its parent and to the first-level item. Now it fixed.